### PR TITLE
Feat: authority check, better configs, shortcuts, custom shortcut

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,9 @@
+import { Schema, Time } from 'koishi'
+
+export interface Config {
+  minInterval?: number
+}
+
+export const Config: Schema<Config> = Schema.object({
+  minInterval: Schema.natural().role('ms').description('允许的最小时间间隔。').default(Time.minute),
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,29 @@
-import { Schema, Time } from 'koishi'
+import { Dict, Schema, Time } from 'koishi'
 
-export interface Config {
+export interface AuthConfig {
   authorityBasic: number
   authorityInterval: number
   authorityFull: number
+}
+
+export interface CustomConfig {
+  customShotrtcut: Dict<string, string>
+}
+
+export interface Config extends AuthConfig, CustomConfig {
   minInterval?: number
 }
 
-export const Config: Schema<Config> = Schema.object({
-  authorityBasic: Schema.number().default(0).description('允许使用定时任务的权限等级。'),
-  authorityInterval: Schema.number().default(0).description('允许使用重复定时任务的权限等级。'),
-  authorityFull: Schema.number().default(0).description('允许查看所有定时任务的权限等级。'),
-  minInterval: Schema.natural().role('ms').description('允许的最小时间间隔。').default(Time.minute),
-})
+export const Config: Schema<Config> = Schema.intersect([
+  Schema.object({
+    authorityBasic: Schema.number().default(0).description('允许使用定时任务的权限等级'),
+    authorityInterval: Schema.number().default(0).description('允许使用重复定时任务的权限等级'),
+    authorityFull: Schema.number().default(0).description('允许查看所有定时任务的权限等级'),
+  }).description('权限配置'),
+  Schema.object({
+    customShotrtcut: Schema.dict(String).role('table').description('自定义快捷指令，每行对应一个，格式和平时调用一样'),
+  }).description('自定义快捷指令'),
+  Schema.object({
+    minInterval: Schema.natural().role('ms').description('允许的最小时间间隔').default(Time.minute),
+  }).description('时间配置'),
+])

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,15 @@
 import { Schema, Time } from 'koishi'
 
 export interface Config {
+  authorityBasic: number
+  authorityInterval: number
+  authorityFull: number
   minInterval?: number
 }
 
 export const Config: Schema<Config> = Schema.object({
+  authorityBasic: Schema.number().default(0).description('允许使用定时任务的权限等级。'),
+  authorityInterval: Schema.number().default(0).description('允许使用重复定时任务的权限等级。'),
+  authorityFull: Schema.number().default(0).description('允许查看所有定时任务的权限等级。'),
   minInterval: Schema.natural().role('ms').description('允许的最小时间间隔。').default(Time.minute),
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,9 +133,13 @@ export function apply(ctx: Context, config: Config) {
         prepareSchedule(schedule, new Session(bot, schedule.session))
       })
     })
+
+    Object.entries(config.customShotrtcut).forEach(([short, command]) => {
+      cmd.shortcut(short, { args: [command] })
+    })
   })
 
-  ctx.command('schedule [time]', { authority: config.authorityBasic, checkUnknown: true })
+  const cmd = ctx.command('schedule [time]', { authority: config.authorityBasic, checkUnknown: true })
     .shortcut('lsschedule', { options: { list: true } })
     .shortcut('delschedule', { options: { delete: true } })
     .option('rest', '-- <command:text>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Context, Dict, Logger, Session, Time } from 'koishi'
 import { Config } from './config'
+import { checkAuth } from './utils'
 
 declare module 'koishi' {
   interface Tables {
@@ -170,14 +171,8 @@ export function apply(ctx: Context, config: Config) {
 
       if (!options.rest) return session.text('.command-expected')
 
-      const cmdStr = options.rest.split(' ')[0]
-      const cmd = ctx.$commander.get(cmdStr)
-      if (!cmd) {
-        return session.text('.command-invalid')
-      }
-      if (cmd.config.authority > session.user.authority) {
-        return session.text('internal.low-authority')
-      }
+      const authCheckRes = await checkAuth(ctx, options.rest, session)
+      if (authCheckRes) return authCheckRes
 
       const dateString = dateSegments.join('-')
       const time = Time.parseDate(dateString)

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export function apply(ctx: Context, config: Config) {
           let output = `${id}. ${formatInterval(time, interval, session)}：${command}`
           if (options.full) {
             output += session.text('.context', [
-              payload.subtype === 'private'
+              payload.isDirect
                 ? session.text('.context.private', payload)
                 : session.text('.context.guild', payload),
             ])

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,12 +134,12 @@ export function apply(ctx: Context, config: Config) {
     })
   })
 
-  ctx.command('schedule [time]', { authority: 3, checkUnknown: true })
+  ctx.command('schedule [time]', { authority: config.authorityBasic, checkUnknown: true })
     .option('rest', '-- <command:text>')
-    .option('interval', '/ <interval:string>', { authority: 4 })
+    .option('interval', '/ <interval:string>', { authority: config.authorityInterval })
     .option('list', '-l')
     .option('ensure', '-e')
-    .option('full', '-f', { authority: 4 })
+    .option('full', '-f', { authority: config.authorityFull })
     .option('delete', '-d <id>')
     .action(async ({ session, options }, ...dateSegments) => {
       if (options.delete) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,8 @@ export function apply(ctx: Context, config: Config) {
   })
 
   ctx.command('schedule [time]', { authority: config.authorityBasic, checkUnknown: true })
+    .shortcut('lsschedule', { options: { list: true } })
+    .shortcut('delschedule', { options: { delete: true } })
     .option('rest', '-- <command:text>')
     .option('interval', '/ <interval:string>', { authority: config.authorityInterval })
     .option('list', '-l')

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,15 @@ export function apply(ctx: Context, config: Config) {
 
       if (!options.rest) return session.text('.command-expected')
 
+      const cmdStr = options.rest.split(' ')[0]
+      const cmd = ctx.$commander.get(cmdStr)
+      if (!cmd) {
+        return session.text('.command-invalid')
+      }
+      if (cmd.config.authority > session.user.authority) {
+        return session.text('internal.low-authority')
+      }
+
       const dateString = dateSegments.join('-')
       const time = Time.parseDate(dateString)
       const timestamp = +time

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -32,6 +32,7 @@ commands:
       create-success: 日程已创建，编号为 {0}。
       list-empty: 当前没有等待执行的日程。
       command-expected: 请输入要执行的指令。
+      command-invalid: 输入的指令不存在。
       date-invalid: 请输入合法的日期。
       date-invalid-suggestion: 请输入合法的日期。你要输入的是不是 {0}s？
       date-expected: 请输入执行时间。

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -21,6 +21,9 @@ commands:
       ensure: 错过时间也确保执行
       full: 查找全部上下文
       delete: 删除已经设置的日程
+    shortcuts:
+      lsschedule: 列出定时任务
+      delschedule: 删除定时任务
     messages:
       context: ，上下文：{0}
       context.private: 私聊 {userId}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,33 @@
+import { Argv, Context, Session } from 'koishi'
+
+export function resolveCommand(argv: Argv, session: Session) {
+  if (!session.inferCommand(argv)) return
+  if (argv.tokens?.every(token => !token.inters.length)) {
+    const { options, args, error } = argv.command.parse(argv)
+    argv.options = { ...argv.options, ...options }
+    argv.args = [...argv.args || [], ...args]
+    argv.error = error
+  }
+  return argv.command
+}
+
+export async function checkAuth(ctx: Context, cmdWithOpt: string, session: Session): Promise<string> {
+  const cmdStr = cmdWithOpt.split(' ')[0]
+  const cmd = ctx.$commander.get(cmdStr)
+
+  if (!cmd) {
+    return session.text('.command-invalid')
+  }
+  if (cmd.config.authority > session.user.authority) {
+    return session.text('internal.low-authority')
+  }
+  const argv = Argv.parse(cmdWithOpt)
+  resolveCommand(argv, session)
+
+  for (const opt of Object.keys(argv.options)) {
+    if (cmd._options[opt]?.authority > session.user.authority) {
+      return session.text('internal.low-authority')
+    }
+  }
+  return ''
+}


### PR DESCRIPTION
Add the following features:
 1. configurable authority level for the `schedule` itself
 2. authority check for commands and options
 3. custom shortcut
 4. updated configuration
 5. 2 shortcuts to quick access list and delete schedules

And:
1. move configs to another script